### PR TITLE
make it work with socket.io 0.9.16

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -65,10 +65,9 @@
                 port: typeof proxy !== 'undefined' ? proxy.port : port,
                 path: requestUrl.pathname + '?t=' + requestUrl.query.t,
                 method: request.method,
-                headers: {
-                    'Host': hostname + ':' + port
-                }
+                headers: request.headers
             };
+            options['headers']['Host'] = hostname + ':' + port；
 
             var proxy_request = requestUrl.query.protocol === 'http'
                 ? http.request(options)


### PR DESCRIPTION
with privoxy 3.0.21 and socket.io 0.9.16, it doesn't work.
copy request header to tunnel proxy's request do the job.
