### PR TITLE
use https-proxy-agent

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@
     var https = require('https');
     var url = require('url');
     var io = require('socket.io-client');
+	var HttpsProxyAgent = require('https-proxy-agent');
 
     // port range, chosen from http://stackoverflow.com/a/28369841
     var tunnelPort = getRandomInt(43124, 44320);
@@ -65,7 +66,7 @@
             }
         }
 
-        var proxy = url.parse(proxyUrl, true);
+		var agent = new HttpsProxyAgent(proxyUrl);
 
         tunnelServer = http.createServer(function (request, response) {
             var requestUrl = url.parse(request.url, true);
@@ -82,13 +83,13 @@
             qs = '?'+qs.join('&');
 
             var options = {
-                hostname: typeof proxy !== 'undefined' ? proxy.hostname : hostname,
-                port: typeof proxy !== 'undefined' ? proxy.port : port,
+                hostname: hostname,
+                port: port,
                 path: requestUrl.pathname + qs,
                 method: request.method,
-                headers: request.headers
+                headers: request.headers,
+				agent: agent
             };
-            options['headers']['Host'] = hostname + ':' + port;
 
             var proxy_request = requestUrl.query.protocol === 'http'
                 ? http.request(options)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "mocha test/*.js"
   },
   "dependencies": {
+    "https-proxy-agent": "^1.0.0",
     "socket.io-client": ">=0.9.16"
   },
   "devDependencies": {
@@ -23,5 +24,5 @@
   "engines": {
     "node": "*"
   },
-  "license" : "MIT"
+  "license": "MIT"
 }


### PR DESCRIPTION
HTTPS wasn't working for me with the url based approach. https-proxy-agent uses CONNECT.  This worksk for me so far.